### PR TITLE
feat: add support for icebreaker credentials

### DIFF
--- a/data/icebreaker.ts
+++ b/data/icebreaker.ts
@@ -1,0 +1,87 @@
+
+
+export type IcebreakerChannel = {
+  type: string;
+  isVerified?: boolean;
+  isLocked?: boolean;
+  value?: string;
+  url?: string;
+};
+
+export type IcebreakerCredential = {
+  name: string;
+  chain: string;
+  source?: string;
+  reference?: string;
+};
+
+export type IcebreakerHighlight = {
+  title?: string;
+  url?: string;
+};
+
+export type IcebreakerWorkExperience = {
+  jobTitle?: string;
+  orgWebsite?: string;
+  employmentType?: string;
+  startDate?: string;
+  endDate?: string;
+  location?: string;
+  isVerified?: boolean;
+};
+
+export type IcebreakerProfile = {
+  profileID?: string;
+  walletAddress: string;
+  avatarUrl?: string;
+  displayName?: string;
+  jobTitle?: string;
+  bio?: string;
+  location?: string;
+  primarySkill?: string;
+  networkingStatus?: string;
+  channels?: IcebreakerChannel[];
+  credentials?: IcebreakerCredential[];
+  highlights?: IcebreakerHighlight[];
+  workExperience?: IcebreakerWorkExperience[];
+};
+
+const API_URL = "https://app.icebreaker.xyz/api/v1";
+
+async function request<T>(path: string, options?: RequestInit): Promise<T | undefined> {
+  try {
+    const response = await fetch(`${API_URL}${path}`, options);
+    
+    if (!response.ok) {
+      throw new Error(`Error: ${response.statusText}`);
+    }
+
+    const data = await response.json() as T;
+    return data;
+  } catch (err) {
+    console.error(err);
+    return undefined;
+  }
+}
+
+type ProfileResponse = {
+  profiles: IcebreakerProfile[];
+};
+
+export async function getIcebreakerbyFid(fid?: number) {
+  if (!fid) {
+    return;
+  }
+
+  const response = await request<ProfileResponse>(`/fid/${fid}`);
+
+  return response?.profiles[0];
+}
+
+export function hasCredential(credentialName?: string, credentials?: IcebreakerCredential[], exact = false) {
+  if (!credentials || !credentialName) {
+    return false;
+  }
+
+  return credentials.some(({ name }) => (exact ? name === credentialName : name.startsWith(credentialName)));
+}

--- a/verifications/icebreaker.ts
+++ b/verifications/icebreaker.ts
@@ -1,0 +1,99 @@
+import { VerificationFunction, VerificationResult } from "."
+import { getIcebreakerbyFid, hasCredential } from '@/data/icebreaker';
+
+export const hasIcebreakerHuman: VerificationFunction = async (
+  fid: number
+): Promise<VerificationResult> => {
+  const credential = "Human";
+
+  const user = await getIcebreakerbyFid(fid);
+
+  if (!user) {
+    return {
+      success: false,
+      message: `${fid} not found in Icebreaker`,
+    };
+  }
+
+  const userHasCredential = hasCredential(credential, user.credentials, true);
+
+  return {
+    success: userHasCredential,
+    message: userHasCredential
+      ? `${fid} has the ${credential} credential`
+      : `${fid} does not have the ${credential} credential`,
+  };
+}
+
+export const hasIcebreakerVerified: VerificationFunction = async (
+  fid: number
+  ): Promise<VerificationResult> => {
+  const credential = "Verified:";
+
+  const user = await getIcebreakerbyFid(fid);
+
+  if (!user) {
+    return {
+      success: false,
+      message: `${fid} not found in Icebreaker`,
+    };
+  }
+
+  const userHasCredential = hasCredential(credential, user.credentials);
+
+  return {
+    success: userHasCredential,
+    message: userHasCredential
+      ? `${fid} has the ${credential} credential`
+      : `${fid} does not have the ${credential} credential`,
+  };
+}
+
+export const hasIcebreakerQBuilder: VerificationFunction = async (
+  fid: number
+  ): Promise<VerificationResult> => {
+  const credential = "qBuilder";
+
+  const user = await getIcebreakerbyFid(fid);
+
+  if (!user) {
+    return {
+      success: false,
+      message: `${fid} not found in Icebreaker`,
+    };
+  }
+
+  const userHasCredential = hasCredential(credential, user.credentials, true);
+
+  return {
+    success: userHasCredential,
+    message: userHasCredential
+      ? `${fid} has the ${credential} credential`
+      : `${fid} does not have the ${credential} credential`,
+  };
+}
+
+// Sample verification function for a non Icebreaker credential. See icebreakerlabs/alloy repo for supported credentials.
+export const hasIcebreakerCoinbaseVerified: VerificationFunction = async (
+  fid: number
+  ): Promise<VerificationResult> => {
+  const credential = "Coinbase Verified";
+
+  const user = await getIcebreakerbyFid(fid);
+
+  if (!user) {
+    return {
+      success: false,
+      message: `${fid} not found in Icebreaker`,
+    };
+  }
+
+  const userHasCredential = hasCredential(credential, user.credentials);
+
+  return {
+    success: userHasCredential,
+    message: userHasCredential
+      ? `${fid} has the ${credential} credential`
+      : `${fid} does not have the ${credential} credential`,
+  };
+}

--- a/verifications/index.ts
+++ b/verifications/index.ts
@@ -5,6 +5,12 @@ import {
   hasVerifiedSolAddress,
   isPowerUser,
 } from "./farcaster";
+import {
+  hasIcebreakerCoinbaseVerified,
+  hasIcebreakerHuman,
+  hasIcebreakerQBuilder,
+  hasIcebreakerVerified,
+} from "./icebreaker";
 import { hasProfileRankBelow200 } from "./openrank";
 import { isSubscribedWithSTP } from "./stp";
 


### PR DESCRIPTION
#### TLDR: Adds support for Icebreaker-powered credentials, including Human, qBuilder, Verified email, and Coinbase Verified

#### Details
- Adds data/icebreaker.ts for library functions to look up Icebreaker profiles by fid and type the responses
- Adds verifications/icebreaker.ts for the specific verification functions. 
   - This can be extended with additional entries for any credential that exists. 
   - When verification functions support additional arguments, this can be generalized as with modbot to take the credential as an argument


Note: I haven't tested this locally yet, but wanted to open the PR quickly for feedback