### PR TITLE
Query Neynar channel members API for specific FID

### DIFF
--- a/data/farcaster.ts
+++ b/data/farcaster.ts
@@ -7,12 +7,12 @@ import { makeWarpcastRequest } from "@/lib/warpcast";
 export type MembersResponse = {
   members: Member[];
 };
-export async function getChannelMembers(): Promise<MembersResponse> {
+export async function getChannelMembers(fid: number): Promise<MembersResponse> {
   const url = "https://api.neynar.com/v2/farcaster/channel/member/list";
   const response = await makeNeynarRequest({
     url,
     method: "GET",
-    queryParams: { channel_id: CHANNEL_ID },
+    queryParams: { channel_id: CHANNEL_ID, fid: fid.toString() },
   });
 
   return response as MembersResponse;

--- a/verifications/farcaster.ts
+++ b/verifications/farcaster.ts
@@ -3,7 +3,7 @@ import * as farcaster from "@/data/farcaster";
 import type { VerificationFunction, VerificationResult } from ".";
 
 export const isMemberOfChannel: VerificationFunction = async (fid: number): Promise<VerificationResult> => {
-  const members = await farcaster.getChannelMembers();
+  const members = await farcaster.getChannelMembers(fid);
 
   return { success: members.members.some((member) => member.user.fid === fid) };
 };


### PR DESCRIPTION
This fixes the bug where the frame says "Invite sent" even if the user is already a channel member. The Neynar API returns channel members in pages of 20 users by default.
